### PR TITLE
Cache and flush + better filepath

### DIFF
--- a/Assets/Perceptor/LogPrecache.cs
+++ b/Assets/Perceptor/LogPrecache.cs
@@ -11,6 +11,13 @@ namespace Rhinox.Perceptor
             public LogLevels Levels;
             public string Message;
             public UnityEngine.Object AssociatedObject;
+
+            public LogEntryCache(LogLevels levels, string message, UnityEngine.Object associatedObject)
+            {
+                Levels = levels;
+                Message = message;
+                AssociatedObject = associatedObject;
+            }
         }
 
         private Dictionary<Type, List<LogEntryCache>> _cache;
@@ -36,14 +43,18 @@ namespace Rhinox.Perceptor
                 _cache.Add(loggerType, new List<LogEntryCache>());
             var list = _cache[loggerType];
             if (list.Count >= _entryLimitPerType)
-                return false;
-            
-            list.Add(new LogEntryCache()
             {
-                Levels = levels,
-                Message = message,
-                AssociatedObject = associatedObject
-            });
+                if (list.Count == _entryLimitPerType)
+                {
+                    list.Add(new LogEntryCache(LogLevels.Warn,
+                        $"The cache for logger of type '{loggerType?.Name}' has overflowed.", null));
+                    
+                    _cache[loggerType] = list;
+                }
+                return false;
+            }
+
+            list.Add(new LogEntryCache(levels, message, associatedObject));
             _cache[loggerType] = list;
             return true;
         }
@@ -53,19 +64,35 @@ namespace Rhinox.Perceptor
         {
             if (_cache == null || _cache.Count == 0)
                 return;
-            
-            foreach (var logger in loggers)
+
+            UnityLogTarget.Silence = true; // NOTE: UnityLogging is already handled while caching, this prevents logging to Unity twice
+            try
             {
-                if (logger == null)
-                    continue;
-                var loggerType = logger.GetType();
-                if (_cache.ContainsKey(loggerType))
+                foreach (var logger in loggers)
                 {
-                    foreach (var entry in _cache[loggerType])
-                        logger.Log(entry.Levels, entry.Message, entry.AssociatedObject);
-                    _cache[loggerType].Clear();
+                    if (logger == null)
+                        continue;
+                    var loggerType = logger.GetType();
+                    if (_cache.ContainsKey(loggerType))
+                    {
+                        foreach (var entry in _cache[loggerType])
+                            logger.Log(entry.Levels, entry.Message, entry.AssociatedObject);
+                        _cache[loggerType].Clear();
+                    }
                 }
             }
+            catch (Exception e)
+            {
+                Debug.LogError($"Something went wrong during FlushCache: " + e.ToString());
+            }
+
+            UnityLogTarget.Silence = false;
+
+            _cache.Clear();
+        }
+
+        public void Clear()
+        {
             _cache.Clear();
         }
     }

--- a/Assets/Perceptor/LogPrecache.cs.meta
+++ b/Assets/Perceptor/LogPrecache.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c3fe829f48414f77bbb085259e3403de
+timeCreated: 1651224283

--- a/Assets/Perceptor/LogTargets/FileLogTarget.cs
+++ b/Assets/Perceptor/LogTargets/FileLogTarget.cs
@@ -61,15 +61,51 @@ namespace Rhinox.Perceptor
             else
             {
 #if UNITY_EDITOR
-                return Path.GetFullPath(Path.Combine(Application.dataPath, "../", filePath));
-#else
+                //return Path.GetFullPath(Path.Combine(Application.dataPath, "../", filePath));
+//#else
                 if (Application.platform == RuntimePlatform.OSXPlayer)
                     return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "/../../../", filePath));
                 else if (Application.platform == RuntimePlatform.WindowsPlayer)
                     return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "/../../", filePath));
+                else if (Application.platform == RuntimePlatform.Android)
+                    return Path.GetFullPath(Path.Combine(GetPersistentDataPath(), filePath));
                 return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, filePath));
 #endif
             }
+        }
+
+        private static string GetPersistentDataPath()
+        {
+            string path = "";
+#if UNITY_ANDROID && !UNITY_EDITOR
+             try 
+             {
+                IntPtr obj_context = AndroidJNI.FindClass("android/content/ContextWrapper");
+                IntPtr method_getFilesDir = AndroidJNIHelper.GetMethodID(obj_context, "getFilesDir", "()Ljava/io/File;");
+     
+                using (AndroidJavaClass cls_UnityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer")) 
+                {
+                    using (AndroidJavaObject obj_Activity = cls_UnityPlayer.GetStatic<AndroidJavaObject>("currentActivity")) 
+                    {
+                        IntPtr file = AndroidJNI.CallObjectMethod(obj_Activity.GetRawObject(), method_getFilesDir, new jvalue[0]);
+                        IntPtr obj_file = AndroidJNI.FindClass("java/io/File");
+                        IntPtr method_getAbsolutePath = AndroidJNIHelper.GetMethodID(obj_file, "getAbsolutePath", "()Ljava/lang/String;");   
+                                     
+                        path = AndroidJNI.CallStringMethod(file, method_getAbsolutePath, new jvalue[0]);                    
+     
+                        if(path == null)
+                            return Application.persistentDataPath;
+                    }
+                }
+            }
+            catch(Exception /*e*/) 
+            {
+                //Debug.Log(e.ToString());
+            }
+#else
+            path = Application.persistentDataPath;
+#endif
+            return path;
         }
 
         protected override void OnLog(LogLevels level, string message, Object associatedObject = null)

--- a/Assets/Perceptor/LogTargets/FileLogTarget.cs
+++ b/Assets/Perceptor/LogTargets/FileLogTarget.cs
@@ -63,6 +63,10 @@ namespace Rhinox.Perceptor
 #if UNITY_EDITOR
                 return Path.GetFullPath(Path.Combine(Application.dataPath, "../", filePath));
 #else
+                if (Application.platform == RuntimePlatform.OSXPlayer)
+                    return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "/../../../", filePath));
+                else if (Application.platform == RuntimePlatform.WindowsPlayer)
+                    return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "/../../", filePath));
                 return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, filePath));
 #endif
             }

--- a/Assets/Perceptor/LogTargets/UnityLogTarget.cs
+++ b/Assets/Perceptor/LogTargets/UnityLogTarget.cs
@@ -4,8 +4,13 @@ namespace Rhinox.Perceptor
 {
     public class UnityLogTarget : BaseLogTarget
     {
+        internal static bool Silence = false;
+        
         protected override void OnLog(LogLevels level, string message, UnityEngine.Object associatedObject = null)
         {
+            if (Silence)
+                return;
+            
             // Also log to Unity
             switch (level)
             {

--- a/Assets/Perceptor/PLog.cs
+++ b/Assets/Perceptor/PLog.cs
@@ -54,9 +54,12 @@ namespace Rhinox.Perceptor
             
             _instance.Loaded = true;
 
-            if (flushPrecacheOnInit)
+            if (_cacheLogger != null)
             {
-                _cacheLogger.FlushCache(_instance._loggerCache.Values);
+                if (flushPrecacheOnInit)
+                    _cacheLogger.FlushCache(_instance._loggerCache.Values);
+                else
+                    _cacheLogger.Clear();
             }
         }
 
@@ -396,16 +399,14 @@ namespace Rhinox.Perceptor
             if (!_loggedWithoutInitialization)
             {
                 UnityEngine.Debug.LogWarning(
-                    $"[WARNING] {nameof(PLog)} hasn't been initialized yet, some of the following lines might not be included in the appropriate logs.");
+                    $"[WARNING] {nameof(PLog)} hasn't been initialized yet, entries will be cached and can be flushed during initialization.");
                 _loggedWithoutInitialization = true;
             }
-
+            
             if (_cacheLogger == null)
                 _cacheLogger = new LogPrecache();
 
-            if (!_cacheLogger.CacheEntry(loggerType, level, message, associatedObject))
-                UnityEngine.Debug.LogWarning(
-                    $"[WARNING] {nameof(PLog)} hasn't been initialized yet, caching entries has been enabled. However, the cache for logger of type '{loggerType?.Name}' has overflowed.");
+            _cacheLogger.CacheEntry(loggerType, level, message, associatedObject);
             
             switch (level)
             {

--- a/Assets/Perceptor/package.json
+++ b/Assets/Perceptor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.perceptor",
   "displayName": "Perceptor - Logging Framework",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "unity": "2019.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changes
- The first 1000 messages per ILogger type are now cached before initialization
- Added flush flag to PLog.CreateIfNotExists(), this will flush all cached messages to the appropriate ILogger instances on initialize
- Base path for log files in builds has been fixed so that they appear relative to the built .exe path (Mac and Windows)