### PR TITLE
Wrongful path concatenation for file target in loggers

### DIFF
--- a/Assets/Perceptor/LogTargets/FileLogTarget.cs
+++ b/Assets/Perceptor/LogTargets/FileLogTarget.cs
@@ -64,9 +64,9 @@ namespace Rhinox.Perceptor
                 return Path.GetFullPath(Path.Combine(Application.dataPath, "../", filePath));
 #else
                 if (Application.platform == RuntimePlatform.OSXPlayer)
-                    return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "/../../../", filePath));
+                    return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "../../..", filePath));
                 else if (Application.platform == RuntimePlatform.WindowsPlayer)
-                    return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "/../../", filePath));
+                    return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, "../..", filePath));
                 else if (Application.platform == RuntimePlatform.Android)
                     return Path.GetFullPath(Path.Combine(GetPersistentDataPath(), filePath));
                 return Path.GetFullPath(Path.Combine(Application.streamingAssetsPath, filePath));

--- a/Assets/Perceptor/package.json
+++ b/Assets/Perceptor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.perceptor",
   "displayName": "Perceptor - Logging Framework",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "unity": "2019.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Fixes
- Fixes wrong path concatenation for FileLogTarget (redirected to root of drive)