### PR TITLE
v0.2.0 release

### DIFF
--- a/Assets/Perceptor/CustomLogger.cs
+++ b/Assets/Perceptor/CustomLogger.cs
@@ -9,6 +9,7 @@ namespace Rhinox.Perceptor
         public LogLevels LogLevel = LogLevels.Debug;
         public bool ShouldThrowErrors = false;
         private readonly List<ILogTarget> _logTargets;
+        private LoggerSettings _currentSettings;
 
         public delegate void LogHandler(LogLevels level, string message, UnityEngine.Object associatedObject = null);
         public event LogHandler Logged; 
@@ -43,7 +44,11 @@ namespace Rhinox.Perceptor
         internal void AppendTarget(ILogTarget target)
         {
             if (target != null && !_logTargets.Contains(target))
+            {
+                if (_currentSettings != null)
+                    target.ApplySettings(_currentSettings);
                 _logTargets.Add(target);
+            }
         }
 
         public void Log(LogLevels level, string message, UnityEngine.Object associatedObject = null)
@@ -73,6 +78,7 @@ namespace Rhinox.Perceptor
             if (settings == null || !settings.CanApplyTo(this))
                 return;
             
+            _currentSettings = settings;
             if (_logTargets == null)
                 return;
 

--- a/Assets/Perceptor/CustomLogger.cs
+++ b/Assets/Perceptor/CustomLogger.cs
@@ -61,7 +61,7 @@ namespace Rhinox.Perceptor
                 if (target == null)
                     continue;
                 
-                target.Log(level, message, associatedObject);
+                target.Log(level, message, associatedObject, this);
             }
             
             TriggerLogged(level, message, associatedObject);

--- a/Assets/Perceptor/ILogTarget.cs
+++ b/Assets/Perceptor/ILogTarget.cs
@@ -2,7 +2,7 @@
 {
     public interface ILogTarget
     {
-        void Log(LogLevels level, string message, UnityEngine.Object associatedObject = null);
+        void Log(LogLevels level, string message, UnityEngine.Object associatedObject = null, ILogger sender = null);
         void ApplySettings(LoggerSettings settings);
         void Update();
     }

--- a/Assets/Perceptor/LogTargets/BaseLogTarget.cs
+++ b/Assets/Perceptor/LogTargets/BaseLogTarget.cs
@@ -8,7 +8,9 @@ namespace Rhinox.Perceptor
         public LogLevels LogLevel { get; protected set; } = LogLevels.Debug;
         public bool ShouldThrowErrors { get; protected set; } = false;
 
-        public void Log(LogLevels level, string message, Object associatedObject = null)
+        protected ILogger ActiveLogger { get; private set; }
+        
+        public void Log(LogLevels level, string message, Object associatedObject = null, ILogger sender = null)
         {
 #if NO_LOGGING
             return;
@@ -19,7 +21,11 @@ namespace Rhinox.Perceptor
             if (LogLevel > level || LogLevel == LogLevels.None)
                 return;
 
+            ActiveLogger = sender;
+
             OnLog(level, message, associatedObject);
+
+            ActiveLogger = null;
         }
 
         protected abstract void OnLog(LogLevels level, string message, Object associatedObject = null);

--- a/Assets/Perceptor/LogTargets/BaseLogTarget.cs
+++ b/Assets/Perceptor/LogTargets/BaseLogTarget.cs
@@ -4,9 +4,9 @@ namespace Rhinox.Perceptor
 {
     public abstract class BaseLogTarget : ILogTarget
     {
-        public bool Muted { get; private set; }
-        public LogLevels LogLevel { get; private set; } = LogLevels.Debug;
-        public bool ShouldThrowErrors { get; private set; } = false;
+        public bool Muted { get; protected set; }
+        public LogLevels LogLevel { get; protected set; } = LogLevels.Debug;
+        public bool ShouldThrowErrors { get; protected set; } = false;
 
         public void Log(LogLevels level, string message, Object associatedObject = null)
         {

--- a/Assets/Perceptor/PLog.cs
+++ b/Assets/Perceptor/PLog.cs
@@ -37,6 +37,9 @@ namespace Rhinox.Perceptor
             // Load loggers
             _instance.LoadLoggerInstances();
             
+            // Load LogTargetCache
+            _instance.TryLoadLogTargetCache();
+            
             // Load logger settings
             LoggerDefaults ld = LoggerDefaults.Instance;
             foreach (var loggerType in _instance._loggerCache.Keys)
@@ -49,9 +52,6 @@ namespace Rhinox.Perceptor
                 }
             }
 
-            // Load LogTargetCache
-            _instance.TryLoadLogTargetCache();
-            
             _instance.Loaded = true;
 
             if (_cacheLogger != null)

--- a/Assets/Perceptor/package.json
+++ b/Assets/Perceptor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.rhinox.open.perceptor",
   "displayName": "Perceptor - Logging Framework",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "unity": "2019.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Fixes
- LogTarget ApplySettings methods invoked in wrong order (some targets missed their settings, depending on initialization order)

### Modified
- Allow inherited LogTargets to access the loglevel settings in order to allow more fine-grained calibration of the behaviour
- Allow access to ILogger from LogTarget log callback (breaking change for ILogTarget implementations)